### PR TITLE
fuzz: exclude the SDK and CRT from code coverage reporting

### DIFF
--- a/test/fuzz/OneFuzzConfig.json
+++ b/test/fuzz/OneFuzzConfig.json
@@ -27,7 +27,8 @@
                 "fuzz-inflate.pdb",
                 "clang_rt.asan_dynamic-x86_64.dll"
             ],
-            "SdlWorkItemId": 58760469
+            "SdlWorkItemId": 58760469,
+            "SourcesAllowListPath": "fuzzing-sources.txt"
         },
         {
             "jobNotificationEmail": "condev@microsoft.com",
@@ -55,7 +56,8 @@
                 "fuzz-inflate64.pdb",
                 "clang_rt.asan_dynamic-x86_64.dll"
             ],
-            "SdlWorkItemId": 58760469
+            "SdlWorkItemId": 58760469,
+            "SourcesAllowListPath": "fuzzing-sources.txt"
         }
     ]
 }

--- a/test/fuzz/fuzzing-sources.txt
+++ b/test/fuzz/fuzzing-sources.txt
@@ -1,0 +1,10 @@
+# When using a source-allow-list (which this is), you have to specify * for everything to be included
+*
+
+# Now, exclude via wildcarded paths all of the following locations.
+# This is because code-coverage data on our fuzzers shouldn't be covering
+# how well we exercise the CRT, STL, etc.
+! *vctools*
+! *externalapis*
+! *internal_shared.h
+! *type_traits


### PR DESCRIPTION
Right now, our coverage sits at 41%. If we exclude the code we did not author, that number should grow to _79%_.